### PR TITLE
Check if control point is running before InspectDevice is called

### DIFF
--- a/Source/Core/PltCtrlPoint.cpp
+++ b/Source/Core/PltCtrlPoint.cpp
@@ -1243,6 +1243,13 @@ PLT_CtrlPoint::InspectDevice(const NPT_HttpUrl& location,
 {
     NPT_AutoLock lock(m_Lock);
 
+    // check if control point has been started
+	if (!m_Started) {
+		NPT_LOG_INFO_1("InspectDevice called before control point started.  location url: %s",
+					   (const char*) location.ToString());
+		return NPT_FAILURE;
+	}
+    
     // check if already inspecting device
     NPT_String pending_uuid;
     if (NPT_SUCCEEDED(NPT_ContainerFind(m_PendingInspections,


### PR DESCRIPTION
Check if control point is running before InspectDevice is called, this fixes a crash.