### PR TITLE
Update build.scons to python 3.12+

### DIFF
--- a/Build/Build.scons
+++ b/Build/Build.scons
@@ -9,7 +9,7 @@ from glob import glob
 def LoadTool(name, env, **kw):
     config_path  = os.path.abspath(GetBuildPath("#/Build/Tools/SCons"))
     file_path = os.path.join(config_path,f"{name}.py")
-    spec = importlib.util.spec_from_file_location("gcc-generic", file_path)
+    spec = importlib.util.spec_from_file_location(name, file_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     module.generate(env, **kw)

--- a/Build/Build.scons
+++ b/Build/Build.scons
@@ -1,15 +1,17 @@
 import sys
 import os
-import imp
+import importlib
 from glob import glob
 
 #######################################################
 # reusable functions and data structures
 #######################################################
 def LoadTool(name, env, **kw):
-    config_path = GetBuildPath('#/Build/Tools/SCons')
-    file, path, desc = imp.find_module(name, [config_path])
-    module = imp.load_module(name, file, path, desc)
+    config_path  = os.path.abspath(GetBuildPath("#/Build/Tools/SCons"))
+    file_path = os.path.join(config_path,f"{name}.py")
+    spec = importlib.util.spec_from_file_location("gcc-generic", file_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     module.generate(env, **kw)
 
 def MergeListUnique(item_list, items):


### PR DESCRIPTION
Due to the deprecation of the imp module in python 3.12 and above, Platinum cannot be built with scons unless python 3.11 and below is installed on the machine. Older out of support versions of python are notorious to obtain especially on Linux Systems. This pull request tweaks the build.scons file for platinum enabling it to be built with modern python versions.