### PR TITLE
Fix memory leak when checking network address

### DIFF
--- a/Source/Core/PltUtilities.h
+++ b/Source/Core/PltUtilities.h
@@ -706,7 +706,10 @@ public:
         
         NPT_List<NPT_NetworkInterface*>::Iterator iface = if_list.GetFirstItem();
         while (iface) {
-            if((*iface)->IsAddressInNetwork(address)) return true;
+            if((*iface)->IsAddressInNetwork(address)) {
+                if_list.Apply(NPT_ObjectDeleter<NPT_NetworkInterface>());   
+                return true;
+            }
             ++iface;
         }
         


### PR DESCRIPTION
Ensure network interfaces are properly deleted after checking the address.

When using Linn Kazoo and an empty playlist  we have a high frequency of subscribe and unsubscribe operations which leads to a fast growing leak in IsLocalNetworkAddress due to missing call to if_list.Apply(NPT_ObjectDeleter<NPT_NetworkInterface>()); on return. Identified with valgrind on x86_64.

```
==4866== 106,518 (27,552 direct, 78,966 indirect) bytes in 492 blocks are definitely lost in loss record 5 of 5
==4866==    at 0x4846FA3: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==4866==    by 0x49860CF: NPT_NetworkInterface::GetNetworkInterfaces(NPT_List<NPT_NetworkInterface*>&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x4926E34: PLT_UPnPMessageHelper::IsLocalNetworkAddress(NPT_IpAddress const&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x4924955: PLT_Service::ProcessNewSubscription(NPT_Reference<PLT_TaskManager>, NPT_SocketAddress const&, NPT_String const&, int, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x49126AB: PLT_DeviceHost::ProcessHttpSubscriberRequest(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x4910BF6: PLT_DeviceHost::SetupResponse(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x48FF0F5: PLT_HttpRequestHandler::SetupResponse(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x4919B67: PLT_HttpServer::SetupResponse(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x491D28B: PLT_HttpServerTask::SetupResponse(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x491BD40: PLT_HttpServerSocketTask::RespondToClient(NPT_HttpRequest&, NPT_HttpRequestContext const&, NPT_HttpResponse*&) (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x491B370: PLT_HttpServerSocketTask::DoRun() (in /opt/tbs/lib/libplatinum.so)
==4866==    by 0x492E4C3: PLT_ThreadTask::Run() (in /opt/tbs/lib/libplatinum.so)
```