### PR TITLE
Always handle subscription expiration

### DIFF
--- a/Source/Core/PltDeviceHost.cpp
+++ b/Source/Core/PltDeviceHost.cpp
@@ -679,8 +679,11 @@ PLT_DeviceHost::ProcessHttpSubscriberRequest(NPT_HttpRequest&              reque
                 goto cleanup;
             }
           
-            // default lease
-            NPT_Int32 timeout = (NPT_Int32)*PLT_Constants::GetInstance().GetDefaultSubscribeLease().AsPointer();
+            NPT_Int32 timeout;
+            if (PLT_UPnPMessageHelper::GetTimeOut(request, timeout) != NPT_SUCCESS) {
+                // default lease
+                timeout = (NPT_Int32)*PLT_Constants::GetInstance().GetDefaultSubscribeLease().AsPointer();
+            }
 
             // subscription renewed
             // send the info to the service
@@ -702,8 +705,11 @@ PLT_DeviceHost::ProcessHttpSubscriberRequest(NPT_HttpRequest&              reque
                 return NPT_SUCCESS;
             }
 
-            // default lease time
-            NPT_Int32 timeout = (NPT_Int32)*PLT_Constants::GetInstance().GetDefaultSubscribeLease().AsPointer();
+            NPT_Int32 timeout;
+            if (PLT_UPnPMessageHelper::GetTimeOut(request, timeout) != NPT_SUCCESS) {
+                // default lease
+                timeout = (NPT_Int32)*PLT_Constants::GetInstance().GetDefaultSubscribeLease().AsPointer();
+            }
 
             // send the info to the service
             service->ProcessNewSubscription(m_TaskManager,

--- a/Source/Core/PltService.cpp
+++ b/Source/Core/PltService.cpp
@@ -791,6 +791,23 @@ PLT_Service::NotifyChanged()
 {
     NPT_AutoLock lock(m_Lock);
 
+    // remove timed out subscriptions
+    {
+        NPT_List<PLT_EventSubscriberReference>::Iterator sub_iter = m_Subscribers.GetFirstItem();
+        NPT_TimeStamp now;
+        NPT_System::GetCurrentTimeStamp(now);
+        while (sub_iter) {
+            PLT_EventSubscriberReference sub = *sub_iter;
+            NPT_TimeStamp expiration;
+            expiration = sub->GetExpirationTime();
+            if (expiration < now ) {
+                m_Subscribers.Erase(sub_iter++);
+            } else {
+                ++sub_iter;
+            }
+        }
+    }
+
     // no eventing for now
     if (m_EventingPaused) return NPT_SUCCESS;
 


### PR DESCRIPTION
Not all apps (example Linn Kazoo on OSX) unsubscribe cleanly. This prevents thread leaking.